### PR TITLE
feat: add expo push token

### DIFF
--- a/src/database/migrations/1755802077298-InitialMigration.ts
+++ b/src/database/migrations/1755802077298-InitialMigration.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InitialMigration1755802077298 implements MigrationInterface {
+  name = 'InitialMigration1755802077298';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "push_token" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "push_token"`);
+  }
+}

--- a/src/users/domain/user.ts
+++ b/src/users/domain/user.ts
@@ -42,6 +42,13 @@ export class User {
   @Expose({ groups: ['me', 'admin'] })
   phone_number: string | null;
 
+  @ApiProperty({
+    type: String,
+    example: 'ExponentPushToken[QxGljeKLHqZPRsgb9R6GxX]',
+  })
+  @Expose({ groups: ['me', 'admin'] })
+  push_token: string | null;
+
   @ApiProperty({ enum: ['Parent', 'Driver'] })
   @Expose({ groups: ['me', 'admin'] })
   kind: UserKind;

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -52,6 +52,14 @@ export class CreateUserDto {
   @IsString()
   phone_number?: string | null;
 
+  @ApiPropertyOptional({
+    example: 'ExponentPushToken[QxGljeKLHqZPRsgb9R6GxX]',
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  push_token?: string | null;
+
   @ApiProperty({ enum: ['Parent', 'Driver', 'Admin'] })
   @IsNotEmpty()
   @IsEnum(['Parent', 'Driver', 'Admin'])

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -54,6 +54,14 @@ export class UpdateUserDto extends PartialType(CreateUserDto) {
   @IsString()
   phone_number?: string | null;
 
+  @ApiPropertyOptional({
+    example: 'ExponentPushToken[QxGljeKLHqZPRsgb9R6GxX]',
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  push_token?: string | null;
+
   @ApiPropertyOptional({ enum: ['Parent', 'Driver', 'Admin'] })
   @IsOptional()
   @IsEnum(['Parent', 'Driver', 'Admin'])

--- a/src/users/infrastructure/persistence/relational/entities/user.entity.ts
+++ b/src/users/infrastructure/persistence/relational/entities/user.entity.ts
@@ -79,6 +79,9 @@ export class UserEntity extends EntityRelationalHelper {
   @Column({ type: 'varchar', nullable: true })
   phone_number: string | null;
 
+  @Column({ type: 'varchar', nullable: true })
+  push_token: string | null;
+
   @Column({
     type: 'varchar',
     nullable: true,

--- a/src/users/infrastructure/persistence/relational/mappers/user.mapper.ts
+++ b/src/users/infrastructure/persistence/relational/mappers/user.mapper.ts
@@ -17,6 +17,7 @@ export class UserMapper {
     domainEntity.lastName = raw.lastName;
     domainEntity.name = raw.name;
     domainEntity.phone_number = raw.phone_number;
+    domainEntity.push_token = raw.push_token;
     domainEntity.kind = raw.kind;
     domainEntity.meta = raw.meta;
     domainEntity.wallet_balance = raw.wallet_balance;
@@ -73,6 +74,7 @@ export class UserMapper {
     persistenceEntity.status = status;
     persistenceEntity.name = domainEntity.name;
     persistenceEntity.phone_number = domainEntity.phone_number;
+    persistenceEntity.push_token = domainEntity.push_token;
     persistenceEntity.kind = domainEntity.kind;
     persistenceEntity.meta = domainEntity.meta;
     persistenceEntity.wallet_balance = domainEntity.wallet_balance;

--- a/src/users/infrastructure/persistence/relational/repositories/user.repository.ts
+++ b/src/users/infrastructure/persistence/relational/repositories/user.repository.ts
@@ -121,25 +121,20 @@ export class UsersRelationalRepository implements UserRepository {
       throw new Error('User not found');
     }
 
-    // Convert existing DB entity to domain
     const currentDomain = UserMapper.toDomain(entity);
 
-    // Merge only provided fields into existing domain object
     const mergedDomain = {
       ...currentDomain,
       ...payload,
     };
 
-    // Convert to persistence object
     const persistenceData = UserMapper.toPersistence(mergedDomain);
 
-    // Remove undefined keys so they won't overwrite existing DB values
     Object.keys(persistenceData).forEach(
       (key) =>
         persistenceData[key] === undefined && delete persistenceData[key],
     );
 
-    // Perform the save (partial overwrite, keeping old values)
     const updatedEntity = await this.usersRepository.save({
       ...entity,
       ...persistenceData,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -129,6 +129,7 @@ export class UsersService {
       firstName: createUserDto.firstName,
       lastName: createUserDto.lastName,
       phone_number: createUserDto.phone_number ?? null,
+      push_token: createUserDto.push_token ?? null,
       kind: createUserDto.kind,
       meta: createUserDto.meta ?? null,
       wallet_balance: createUserDto.wallet_balance ?? 0,
@@ -293,6 +294,7 @@ export class UsersService {
       firstName: updateUserDto.firstName,
       lastName: updateUserDto.lastName,
       phone_number: updateUserDto.phone_number,
+      push_token: updateUserDto.push_token,
       kind: updateUserDto.kind,
       meta: updateUserDto.meta,
       wallet_balance: updateUserDto.wallet_balance,
@@ -311,50 +313,4 @@ export class UsersService {
   async remove(id: User['id']): Promise<void> {
     await this.usersRepository.remove(id);
   }
-
-  // async updateNotifications(
-  //   userId: number,
-  //   notifications: UserMeta['notifications'],
-  // ): Promise<User | null> {
-  //   const user = await this.findById(userId);
-
-  //   if (!user) throw new NotFoundException('User not found');
-
-  //   const currentMeta = user.meta ?? {
-  //     payments: {
-  //       kind: 'Bank',
-  //       bank: null,
-  //       account_number: null,
-  //       account_name: null,
-  //     },
-  //     notifications: {
-  //       when_bus_leaves: false,
-  //       when_bus_makes_home_drop_off: false,
-  //       when_bus_make_home_pickup: false,
-  //       when_bus_arrives: false,
-  //       when_bus_is_1km_away: false,
-  //       when_bus_is_0_5km_away: false,
-  //     },
-  //     county: null,
-  //     neighborhood: null,
-  //   };
-
-  //   return this.update(userId, {
-  //     meta: {
-  //       ...currentMeta,
-  //       payments: currentMeta.payments ?? {
-  //         kind: 'Bank',
-  //         bank: null,
-  //         account_number: null,
-  //         account_name: null,
-  //       },
-  //       notifications: {
-  //         ...currentMeta.notifications,
-  //         ...notifications,
-  //       },
-  //       county: currentMeta.county ?? null,
-  //       neighborhood: currentMeta.neighborhood ?? null,
-  //     },
-  //   });
-  // }
 }


### PR DESCRIPTION
# feat: add expo push token

## Description
This PR introduces support for storing Expo push tokens in the backend.

### Changes include
- Added `push_token` column to the `user` table through a new migration.
- Updated `User` domain model to include `push_token`.
- Updated `CreateUserDto` and `UpdateUserDto` to allow optional `push_token`.
- Updated `UserEntity` to persist `push_token`.
- Updated `UserMapper` for domain ↔ persistence mapping of `push_token`.
- Updated `UsersService` to handle `push_token` on create and update.
- Cleaned up old commented-out notification update logic.

## Why
This enables push notifications through Expo by associating each user with their device’s push token.

## Testing
- Run migrations to apply the new column.
- Create a user with a `push_token` and confirm it is stored in the database.
- Update a user’s `push_token` and verify persistence.
- Fetch user details and confirm `push_token` is exposed in the API response.

## Closes
Closes #<issue-number-if-any>

## Reviewer
@FridahWatetuMuthoni
